### PR TITLE
🧹 [Cleanup 'cleanup' argument in list_caches]

### DIFF
--- a/docs/google-cloud-gemini-cookbook/lesson-04/cache.py
+++ b/docs/google-cloud-gemini-cookbook/lesson-04/cache.py
@@ -111,9 +111,11 @@ class CacheManager:
             print(f" - Expires at: {content_cache.expire_time}")
 
             # cleanup
-            if content_cache.display_name != config.CACHE_FILE:
-                continue
-            self.client.caches.delete(content_cache.name)
+            if cleanup and content_cache.display_name == config.CACHE_NAME:
+                print(
+                    f" - Deleting Cache: {content_cache.display_name} ({content_cache.name})"
+                )
+                self.client.caches.delete(content_cache.name)
 
     def main(self):
         cache_name, creation_datetime_object, is_valid_flag = (

--- a/docs/google-cloud-gemini-cookbook/lesson-04/test_cache_manager.py
+++ b/docs/google-cloud-gemini-cookbook/lesson-04/test_cache_manager.py
@@ -1,0 +1,71 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+import os
+
+# Add the directory containing cache.py and config.py to sys.path
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+# Mock the entire google.genai module before importing cache
+mock_genai = MagicMock()
+sys.modules['google'] = MagicMock()
+sys.modules['google.genai'] = mock_genai
+sys.modules['google.genai.types'] = MagicMock()
+
+from cache import CacheManager
+import config
+
+class TestCacheManager(unittest.TestCase):
+    def setUp(self):
+        # Reset the mock client for each test
+        with patch('cache.genai.Client') as mock_client_class:
+            self.mock_client = mock_client_class.return_value
+            self.cache_manager = CacheManager()
+
+    def test_list_caches_no_cleanup(self):
+        # Setup mock caches
+        mock_cache = MagicMock()
+        mock_cache.display_name = config.CACHE_NAME
+        mock_cache.name = "projects/123/locations/us-central1/cachedContents/456"
+        mock_cache.model = "gemini-1.5-flash"
+        mock_cache.update_time = "2023-01-01T00:00:00Z"
+        mock_cache.expire_time = "2023-01-01T01:00:00Z"
+
+        self.mock_client.caches.list.return_value = [mock_cache]
+
+        # Call list_caches with cleanup=False
+        self.cache_manager.list_caches(cleanup=False)
+
+        # Verify delete was NOT called
+        self.mock_client.caches.delete.assert_not_called()
+
+    def test_list_caches_with_cleanup_matching_name(self):
+        # Setup mock caches
+        mock_cache = MagicMock()
+        mock_cache.display_name = config.CACHE_NAME
+        mock_cache.name = "projects/123/locations/us-central1/cachedContents/456"
+
+        self.mock_client.caches.list.return_value = [mock_cache]
+
+        # Call list_caches with cleanup=True
+        self.cache_manager.list_caches(cleanup=True)
+
+        # Verify delete WAS called with the correct name
+        self.mock_client.caches.delete.assert_called_once_with(mock_cache.name)
+
+    def test_list_caches_with_cleanup_non_matching_name(self):
+        # Setup mock caches
+        mock_cache = MagicMock()
+        mock_cache.display_name = "OTHER-CACHE"
+        mock_cache.name = "projects/123/locations/us-central1/cachedContents/789"
+
+        self.mock_client.caches.list.return_value = [mock_cache]
+
+        # Call list_caches with cleanup=True
+        self.cache_manager.list_caches(cleanup=True)
+
+        # Verify delete was NOT called because name doesn't match
+        self.mock_client.caches.delete.assert_not_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Fixed unused `cleanup` argument in `list_caches` method of `CacheManager` class. Updated the logic to correctly use `config.CACHE_NAME` instead of the local `config.CACHE_FILE` for cloud cache identification.

💡 **Why:** Improves code readability and maintainability by removing dead code and correcting logically confusing variable references.

✅ **Verification:** Created and ran a mock-based unit test suite (`test_cache_manager.py`) that verified `list_caches` correctly deletes caches when `cleanup=True` and only for matching names, while doing nothing when `cleanup=False`.

✨ **Result:** Correct implementation of the `cleanup` flag and accurate cache identification in the listing process.

---
*PR created automatically by Jules for task [3511051066958326340](https://jules.google.com/task/3511051066958326340) started by @msampathkumar*