### PR TITLE
🔒 [security fix] Fix Insecure Cloud Run Deployment Configuration: Allow Unauthenticated Access

### DIFF
--- a/docs/google-cloud-gemini-cookbook/lesson-01/README.md
+++ b/docs/google-cloud-gemini-cookbook/lesson-01/README.md
@@ -137,7 +137,7 @@ PROJECT="your-gcp-project-id"
 LOCATION="us-central1"
 
 # Deploy app from source code
-gcloud run deploy simple-app --source . --region=$LOCATION --project=$PROJECT --allow-unauthenticated
+gcloud run deploy simple-app --source . --region=$LOCATION --project=$PROJECT --no-allow-unauthenticated
 ```
 
 **Important:** Replace `"your-gcp-project-id"` with your actual Google Cloud

--- a/docs/google-cloud-gemini-cookbook/lesson-01/deploy.sh
+++ b/docs/google-cloud-gemini-cookbook/lesson-01/deploy.sh
@@ -18,4 +18,4 @@ gcloud run deploy simple-app --source . \
   --region=$GOOGLE_CLOUD_LOCATION \
   --project=$GOOGLE_CLOUD_PROJECT \
   --set-env-vars=$CLOUD_RUN_INSTANCE_ENV_VARS \
-  --allow-unauthenticated
+  --no-allow-unauthenticated

--- a/docs/google-cloud-gemini-cookbook/lesson-02/deploy.sh
+++ b/docs/google-cloud-gemini-cookbook/lesson-02/deploy.sh
@@ -18,4 +18,4 @@ gcloud run deploy simple-app --source . \
   --region=$GOOGLE_CLOUD_LOCATION \
   --project=$GOOGLE_CLOUD_PROJECT \
   --set-env-vars=$CLOUD_RUN_INSTANCE_ENV_VARS \
-  --allow-unauthenticated
+  --no-allow-unauthenticated

--- a/docs/google-cloud-gemini-cookbook/lesson-03/deploy.sh
+++ b/docs/google-cloud-gemini-cookbook/lesson-03/deploy.sh
@@ -18,4 +18,4 @@ gcloud run deploy simple-app --source . \
   --region=$GOOGLE_CLOUD_LOCATION \
   --project=$GOOGLE_CLOUD_PROJECT \
   --set-env-vars=$CLOUD_RUN_INSTANCE_ENV_VARS \
-  --allow-unauthenticated
+  --no-allow-unauthenticated

--- a/docs/google-cloud-gemini-cookbook/lesson-04/deploy
+++ b/docs/google-cloud-gemini-cookbook/lesson-04/deploy
@@ -18,4 +18,4 @@ gcloud run deploy simple-app --source . \
   --region=$GOOGLE_CLOUD_LOCATION \
   --project=$GOOGLE_CLOUD_PROJECT \
   --set-env-vars=$CLOUD_RUN_INSTANCE_ENV_VARS \
-  --allow-unauthenticated
+  --no-allow-unauthenticated

--- a/docs/google-cloud-gemini-cookbook/lesson-04/deploy.sh
+++ b/docs/google-cloud-gemini-cookbook/lesson-04/deploy.sh
@@ -18,4 +18,4 @@ gcloud run deploy simple-app --source . \
   --region=$GOOGLE_CLOUD_LOCATION \
   --project=$GOOGLE_CLOUD_PROJECT \
   --set-env-vars=$CLOUD_RUN_INSTANCE_ENV_VARS \
-  --allow-unauthenticated
+  --no-allow-unauthenticated


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was an insecure deployment configuration that allowed unauthenticated access to Cloud Run services.
⚠️ **Risk:** Allowing unauthenticated access would have meant that any person with the service URL could access the deployed application without any form of authentication, potentially leading to unauthorized data access or resource consumption.
🛡️ **Solution:** Modified the deployment scripts (`deploy.sh`, `deploy`) and documentation (`README.md`) in `lesson-01` through `lesson-04` of the Google Cloud Gemini Cookbook to use the `--no-allow-unauthenticated` flag instead of `--allow-unauthenticated`. This ensures that the services are private by default and require IAM authentication for access.


---
*PR created automatically by Jules for task [3169543609190850696](https://jules.google.com/task/3169543609190850696) started by @msampathkumar*